### PR TITLE
[CB-214] 카카오 sdk 로그아웃, 회원 탈퇴 연결 완료

### DIFF
--- a/lib/page/appleloginwebview.dart
+++ b/lib/page/appleloginwebview.dart
@@ -45,6 +45,7 @@ class _AppleLoginWebviewState extends State<AppleLoginWebview> {
     await checkStatus().then((wasUser) {
       if (wasUser) {
         // 이전에 로그인한 기록이 있다면, 홈 화면으로 이동 (이전 stack 비우기)
+        //태현 : 홈 화면으로 리다이렉트. 즉 재로그인
         Navigator.pushAndRemoveUntil(
             context,
             MaterialPageRoute(builder: (BuildContext context) => const App()),
@@ -52,6 +53,7 @@ class _AppleLoginWebviewState extends State<AppleLoginWebview> {
       } else {
         // 이전에 로그인한 기록이 없다면, 로그인 화면으로 이동 (이전 stack 비우기)
         Navigator.pushNamedAndRemoveUntil(
+          //태현 : 애플 신규 회원가입
             context, '/termscheck', (route) => false);
       }
     });

--- a/lib/page/appleloginwebview.dart
+++ b/lib/page/appleloginwebview.dart
@@ -33,31 +33,68 @@ class _AppleLoginWebviewState extends State<AppleLoginWebview> {
     );
   }
 
-  Future<bool> checkStatus() async {
-    //prefs.clear();
-    // TODO : 닉네임을 설정 완료 했는지 여부를 확인하는 API 호출
-    bool isNickname = true;
-    print("[*] 닉네임 설정 상태 : " + isNickname.toString());
-    return isNickname;
-  }
+  void checkStatus() async {
+    SharedPreferences prefs = await SharedPreferences
+        .getInstance(); // getInstance로 기기 내 shared_prefs 객체를 가져온다.
 
-  void moveScreen() async {
-    await checkStatus().then((wasUser) {
-      if (wasUser) {
-        // 이전에 로그인한 기록이 있다면, 홈 화면으로 이동 (이전 stack 비우기)
+    //prefs.clear();
+    // TODO : 닉네임 설정 완료 여부를 확인하는 API를 호출하는 부분
+    bool hasToken = false;
+    String? userToken = prefs.getString("userToken");
+
+    if (userToken != null) {
+      hasToken = true;
+      Map<String, dynamic> payload = Jwt.parseJwt(userToken);
+
+      String userId = payload['id'].toString();
+
+      String tmpUrl = 'https://www.chocobread.shop/users/check/' + userId;
+      var url = Uri.parse(
+        tmpUrl,
+      );
+      var response = await http.get(url);
+      String responseBody = utf8.decode(response.bodyBytes);
+      Map<String, dynamic> list = jsonDecode(responseBody);
+      print("splash에서의 list : ${list}");
+      if (list['code'] == 200) {
+        print("코드가 200입니다. 홈화면으로 리다이렉트합니다.");
         //태현 : 홈 화면으로 리다이렉트. 즉 재로그인
         Navigator.pushAndRemoveUntil(
             context,
             MaterialPageRoute(builder: (BuildContext context) => const App()),
             (route) => false);
-      } else {
-        // 이전에 로그인한 기록이 없다면, 로그인 화면으로 이동 (이전 stack 비우기)
+      } else if (list['code'] == 300 || list['code'] == 404) {
+        print("코드가 ${list['code']}입니다. 약관동의 화면으로 리다이렉트합니다.");
         Navigator.pushNamedAndRemoveUntil(
-          //태현 : 애플 신규 회원가입
             context, '/termscheck', (route) => false);
+      } else {
+        print("서버 에러가 발생하였습니다. 로그인 화면으로 리다이렉트합니다.");
+        Navigator.pushNamedAndRemoveUntil(context, '/login', (route) => false);
       }
-    });
+    } else {
+      //토큰이 로컬 스토리지에 없으면 로그인 화면으로 이동.
+      Navigator.pushNamedAndRemoveUntil(context, '/login', (route) => false);
+    }
+    print("[*] 유저 토큰 : " + userToken.toString());
   }
+
+  // void moveScreen() async {
+  //   await checkStatus().then((wasUser) {
+  //     if (wasUser) {
+  //       // 이전에 로그인한 기록이 있다면, 홈 화면으로 이동 (이전 stack 비우기)
+  //       //태현 : 홈 화면으로 리다이렉트. 즉 재로그인
+  //       Navigator.pushAndRemoveUntil(
+  //           context,
+  //           MaterialPageRoute(builder: (BuildContext context) => const App()),
+  //           (route) => false);
+  //     } else {
+  //       // 이전에 로그인한 기록이 없다면, 로그인 화면으로 이동 (이전 stack 비우기)
+  //       Navigator.pushNamedAndRemoveUntil(
+  //         //태현 : 애플 신규 회원가입
+  //           context, '/termscheck', (route) => false);
+  //     }
+  //   });
+  // }
 
   Widget _appleLoginWebview() {
     return InAppWebView(
@@ -74,17 +111,11 @@ class _AppleLoginWebviewState extends State<AppleLoginWebview> {
           // List<Cookie> cookies = await _cookieManager.getCookies(url: myurl);
           Cookie? cookie =
               await _cookieManager.getCookie(url: myurl, name: "accessToken");
-          if (cookie != null) {}
-          // print("start");
           final prefs = await SharedPreferences.getInstance();
-          // print(cookie);
-          // print("end");
           if (cookie != null) {
-            // prefs.setBool("isLogin", true);
-            // print(prefs.getBool("isLogin"));
             prefs.setString("userToken", cookie.value);
             sendSignupToAirbridge();
-            moveScreen();
+            checkStatus();
             // Navigator.pushNamedAndRemoveUntil(
             //     context, "/termscheck", (r) => false);
           }

--- a/lib/page/login.dart
+++ b/lib/page/login.dart
@@ -256,6 +256,7 @@ class _LoginState extends State<Login> {
         }
         if (code == 200) {
           print("code가 200입니다. 홈 화면으로 리다이렉트합니다.");
+          //태현 : 홈 화면으로 리다이렉트. 즉 재로그인
           Navigator.pushAndRemoveUntil(
               context,
               MaterialPageRoute(builder: (BuildContext context) => const App()),

--- a/lib/page/mypage.dart
+++ b/lib/page/mypage.dart
@@ -14,6 +14,7 @@ import 'package:chocobread/utils/datetime_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:jwt_decode/jwt_decode.dart';
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'repository/contents_repository.dart' as cont;
 import 'repository/userInfo_repository.dart';
@@ -111,13 +112,15 @@ class _MyPageState extends State<MyPage> {
                                     print(
                                         'logout provider is ${payload['provider']}');
                                     prefs.remove('userToken');
-                                    print("move to kakao logout webviewPage");
-                                    Navigator.pushAndRemoveUntil(
-                                        context,
-                                        MaterialPageRoute(
-                                            builder: (BuildContext context) =>
-                                                KakaoLogoutWebview()),
-                                        (route) => false);
+                                    try {
+                                      await UserApi.instance.logout();
+                                      print('로그아웃 성공, SDK에서 토큰 삭제');
+                                    } catch (error) {
+                                      print('로그아웃 실패, SDK에서 토큰 삭제 $error');
+                                    }
+                                    print("move to loginPage");
+                                     Navigator.pushNamedAndRemoveUntil(
+                                        context, '/login', (route) => false);
                                     // kakaoLogout();
                                   } else if (payload['provider'] == 'apple') {
                                     print(
@@ -609,6 +612,8 @@ class _MyPageState extends State<MyPage> {
 
       String provider = payload['provider'].toString();
       print("provider is ${provider} on resign api");
+      
+      
 
       String tmpUrl =
           'https://www.chocobread.shop/auth/' + provider + '/signout';

--- a/lib/page/mypage.dart
+++ b/lib/page/mypage.dart
@@ -119,7 +119,7 @@ class _MyPageState extends State<MyPage> {
                                       print('로그아웃 실패, SDK에서 토큰 삭제 $error');
                                     }
                                     print("move to loginPage");
-                                     Navigator.pushNamedAndRemoveUntil(
+                                    Navigator.pushNamedAndRemoveUntil(
                                         context, '/login', (route) => false);
                                     // kakaoLogout();
                                   } else if (payload['provider'] == 'apple') {
@@ -363,8 +363,7 @@ class _MyPageState extends State<MyPage> {
                               horizontal: 7, vertical: 3),
                           decoration: BoxDecoration(
                             borderRadius: BorderRadius.circular(20),
-                            color: _colorMyStatus(dataOngoing[index]
-                                    ["mystatus"]
+                            color: _colorMyStatus(dataOngoing[index]["mystatus"]
                                 .toString()
                                 .substring(0, 2)), // 제안자 참여자를 제안 참여로 처리
                           ),
@@ -612,8 +611,16 @@ class _MyPageState extends State<MyPage> {
 
       String provider = payload['provider'].toString();
       print("provider is ${provider} on resign api");
-      
-      
+
+      if (provider == "kakao") {
+        provider = "kakaosdk";
+        try {
+          await UserApi.instance.unlink();
+          print('연결 끊기 성공, SDK에서 토큰 삭제');
+        } catch (error) {
+          print('연결 끊기 실패 $error');
+        }
+      }
 
       String tmpUrl =
           'https://www.chocobread.shop/auth/' + provider + '/signout';
@@ -621,7 +628,7 @@ class _MyPageState extends State<MyPage> {
       var url = Uri.parse(
         tmpUrl,
       );
-      var response = await http.get(url, headers: {
+      var response = await http.delete(url, headers: {
         'Authorization': token,
         'Content-Type': 'application/x-www-form-urlencoded'
       });

--- a/lib/page/nicknameset.dart
+++ b/lib/page/nicknameset.dart
@@ -342,7 +342,7 @@ class _NicknameSetState extends State<NicknameSet> {
                           nicknameSetController.text; // 현재 닉네임을 나타내는 변수
                       print("닉네임 제출하려는 닉네임은 " + nicknametosubmit);
                       //SET NICKNAME API CALL
-                      nicknameSet(nicknametosubmit);
+                      nicknameSet(nicknametosubmit);  //태현 : 닉네임 설정 api가 여기서 호출. 즉 신규회원가입 완료.
                       //채은 : 좌표넣기
                       // await setUserLocation("37.5037142", "127.0447821");
                       // setState(() {

--- a/lib/page/splash/splash.dart
+++ b/lib/page/splash/splash.dart
@@ -43,6 +43,7 @@ class _SplashState extends State<Splash> {
       print("splash에서의 list : ${list}");
       if (list['code'] == 200) {
         print("코드가 200입니다. 홈화면으로 리다이렉트합니다.");
+        //태현 : 홈 화면으로 리다이렉트. 즉 재로그인
         Navigator.pushAndRemoveUntil(
             context,
             MaterialPageRoute(builder: (BuildContext context) => const App()),

--- a/lib/page/splash/splash.dart
+++ b/lib/page/splash/splash.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
-
+import 'dart:convert';
+import 'package:http/http.dart' as http;
 import 'package:chocobread/constants/sizes_helper.dart';
 import 'package:chocobread/page/app.dart';
 import 'package:chocobread/style/colorstyles.dart';
 import 'package:flutter/material.dart';
+import 'package:jwt_decode/jwt_decode.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class Splash extends StatefulWidget {
@@ -16,34 +18,64 @@ class Splash extends StatefulWidget {
 class _SplashState extends State<Splash> {
   // static String routeName = "/splash";
 
-  Future<bool> checkStatus() async {
+  void checkStatus() async {
     SharedPreferences prefs = await SharedPreferences
         .getInstance(); // getInstance로 기기 내 shared_prefs 객체를 가져온다.
 
     //prefs.clear();
     // TODO : 닉네임 설정 완료 여부를 확인하는 API를 호출하는 부분
-    bool isNickname = prefs.getBool("isNickname") ?? false; // 닉네임을 설정했는지 여부
+    bool hasToken = false;
     String? userToken = prefs.getString("userToken");
 
-    print("[*] 닉네임 설정 상태 : " + isNickname.toString());
-    print("[*] 유저 토큰 : " + userToken.toString());
-    return isNickname;
-  }
+    if (userToken != null) {
+      hasToken = true;
+      Map<String, dynamic> payload = Jwt.parseJwt(userToken);
 
-  void moveScreen() async {
-    await checkStatus().then((wasUser) {
-      if (wasUser) {
-        // 이전에 로그인한 기록이 있다면, 홈 화면으로 이동 (이전 stack 비우기)
+      String userId = payload['id'].toString();
+
+      String tmpUrl = 'https://www.chocobread.shop/users/check/' + userId;
+      var url = Uri.parse(
+        tmpUrl,
+      );
+      var response = await http.get(url);
+      String responseBody = utf8.decode(response.bodyBytes);
+      Map<String, dynamic> list = jsonDecode(responseBody);
+      print("splash에서의 list : ${list}");
+      if (list['code'] == 200) {
+        print("코드가 200입니다. 홈화면으로 리다이렉트합니다.");
         Navigator.pushAndRemoveUntil(
             context,
             MaterialPageRoute(builder: (BuildContext context) => const App()),
             (route) => false);
+      } else if (list['code'] == 300 || list['code'] == 404) {
+        print("코드가 ${list['code']}입니다. 약관동의 화면으로 리다이렉트합니다.");
+        Navigator.pushNamedAndRemoveUntil(
+              context, '/termscheck', (route) => false);
       } else {
-        // 이전에 로그인한 기록이 없다면, 로그인 화면으로 이동 (이전 stack 비우기)
+        print("서버 에러가 발생하였습니다. 로그인 화면으로 리다이렉트합니다.");
         Navigator.pushNamedAndRemoveUntil(context, '/login', (route) => false);
       }
-    });
+    } else {
+      //토큰이 로컬 스토리지에 없으면 로그인 화면으로 이동.
+      Navigator.pushNamedAndRemoveUntil(context, '/login', (route) => false);
+    }
+    print("[*] 유저 토큰 : " + userToken.toString());
   }
+
+  // void moveScreen() async {
+  //   await checkStatus().then((hasToken) {
+  //     if (hasToken) {
+  //       // 이전에 로그인한 기록이 있다면, 홈 화면으로 이동 (이전 stack 비우기)
+  //       Navigator.pushAndRemoveUntil(
+  //           context,
+  //           MaterialPageRoute(builder: (BuildContext context) => const App()),
+  //           (route) => false);
+  //     } else {
+  //       // 이전에 로그인한 기록이 없다면, 로그인 화면으로 이동 (이전 stack 비우기)
+  //       Navigator.pushNamedAndRemoveUntil(context, '/login', (route) => false);
+  //     }
+  //   });
+  // }
 
   // sharedPreferences 초기화 위해 사용하는 함수
   void clearSharedPreferences() async {
@@ -56,7 +88,7 @@ class _SplashState extends State<Splash> {
     super.initState();
     Timer(Duration(seconds: 2), () {
       // clearSharedPreferences(); // sharedPreferences 초기화 위해 사용하는 함수
-      moveScreen();
+      checkStatus();
     });
   }
 

--- a/lib/page/termscheck.dart
+++ b/lib/page/termscheck.dart
@@ -418,7 +418,7 @@ class _TermsCheckState extends State<TermsCheck> {
           ),
           onPressed: (isServiceChecked && isPersonalChecked) // 모두 체크한 경우
               ? () {
-                //임시로 추가한 nickname set 페이지 이동 코드
+                //혜연 : 임시로 추가한 nickname set 페이지 이동 코드
                 Navigator.push(context,
                           MaterialPageRoute(builder: (BuildContext context) {
                         return NicknameSet();


### PR DESCRIPTION
[CB-214]
카카오 sdk 로그아웃, 회원 탈퇴 api 연결
에어브릿지, 파이어베이스 연결을 위한 회원가입, 재로그인 여부 판별 및 주석 추가 : 태현으로 검색하기

애플 웹뷰 로그인에서 토큰으로 쿠키값 반환. 그 쿠키를 decode해서 id추출.
이후 해당 id를 path variable로 받아 users/check/:userId api호출
위 api의 return code에 따라 화면 이동
200 : 홈 화면 이동(이미 로그인을 완료한 유저)
300 : 약관동의 화면 이동(로그인 진행을 완료하지 않은 유저)

[CB-214]: https://chocobread.atlassian.net/browse/CB-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ