### PR TITLE
[CB-214]db의 curLocation3이 비어있으면 local Storage에 '위치를 알 수 없는 사용자입니다' 저장

### DIFF
--- a/lib/page/login.dart
+++ b/lib/page/login.dart
@@ -281,9 +281,18 @@ class _LoginState extends State<Login> {
               var response = await http.get(url);
               String responseBody = utf8.decode(response.bodyBytes);
               Map<String, dynamic> list = jsonDecode(responseBody);
-              prefs.setString("userLocation", list['result']['addr']);
-              print(
-                  "curLocation을 db에서 가져왔습니다. 현재 로컬 스토리지에 저장된 curLocation은 ${prefs.getString('userLocation')}입니다");
+              if (list['result']['addr'] == null) {
+                prefs.setString("userLocation", "위치를 알 수 없는 사용자입니다");
+                print(
+                    "curLocation을 db에서 가져오려했으나 null입니다. 현재 로컬 스토리지에 저장된 curLocation은 ${prefs.getString('userLocation')}입니다");
+              }
+              else{
+                prefs.setString("userLocation", list['result']['addr']);
+                print(
+                    "curLocation을 db에서 가져왔습니다. 현재 로컬 스토리지에 저장된 curLocation은 ${prefs.getString('userLocation')}입니다");
+              }
+              
+              
             } else {
               print("token is null");
             }


### PR DESCRIPTION
[CB-214]
애뮬레이터로 회원가입을 할 경우 curLocation이 비어있게 되어 아래 에러 발견.

로그인 시 currentLocation이 비어있으면 db에서 curLocation3값을 받아와 local Storage에 저장하는데, 이 값이 null이면 localStorage에 값을 저장하는 부분에서 에러 발생. 

그래서 db가 비어있으면 local Storage에 "위치를 알 수 없는 사용자입니다" 저장하도록 변경.

[CB-214]: https://chocobread.atlassian.net/browse/CB-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ