### PR TITLE
Feature/photo permission cb 233

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -232,7 +232,7 @@ SPEC CHECKSUMS:
   FirebaseCoreDiagnostics: 17cbf4e72b1dbd64bfdc33d4b1f07bce4f16f1d8
   FirebaseCoreInternal: 50a8e39cae8abf72d5145d07ea34c3244f70862b
   FirebaseInstallations: 41f811b530c41dd90973d0174381cdb3fcb5e839
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec

--- a/lib/page/checkmovetophotosettings.dart
+++ b/lib/page/checkmovetophotosettings.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 
-class CheckMoveToSettings extends StatefulWidget {
-  CheckMoveToSettings({Key? key}) : super(key: key);
+class CheckMoveToPhotoSettings extends StatefulWidget {
+  CheckMoveToPhotoSettings({Key? key}) : super(key: key);
 
   @override
-  State<CheckMoveToSettings> createState() => _CheckMoveToSettingsState();
+  State<CheckMoveToPhotoSettings> createState() =>
+      _CheckMoveToPhotoSettingsState();
 }
 
-class _CheckMoveToSettingsState extends State<CheckMoveToSettings> {
+class _CheckMoveToPhotoSettingsState extends State<CheckMoveToPhotoSettings> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(

--- a/lib/page/checkmovetosettings.dart
+++ b/lib/page/checkmovetosettings.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class CheckMoveToSettings extends StatefulWidget {
+  CheckMoveToSettings({Key? key}) : super(key: key);
+
+  @override
+  State<CheckMoveToSettings> createState() => _CheckMoveToSettingsState();
+}
+
+class _CheckMoveToSettingsState extends State<CheckMoveToSettings> {
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text("모든 권한을 허용해주세요."),
+      content: const Text("권한을 허용해야 사진을 업로드할 수 있습니다."),
+      actions: [
+        TextButton(
+            onPressed: () {
+              // 설정으로 이동할지 물어보는 alert dialog에서 취소를 누르면, alert dialog와 bottomsheet 모두 사라진다.
+              int count = 0;
+              Navigator.of(context).popUntil((_) => count++ >= 2);
+            },
+            child: const Text("취소")),
+        TextButton(
+            onPressed: () {
+              // 설정으로 이동하기 버튼을 누른 경우, 설정으로 이동한다.
+              openAppSettings();
+            },
+            child: const Text("설정으로 이동"))
+      ],
+    );
+  }
+}

--- a/lib/page/form.dart
+++ b/lib/page/form.dart
@@ -17,7 +17,7 @@ import 'package:intl/intl.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../utils/datetime_utils.dart';
-import 'checkmovetosettings.dart';
+import 'checkmovetophotosettings.dart';
 import 'repository/contents_repository.dart' as contents;
 import 'package:dio/dio.dart';
 import 'package:airbridge_flutter_sdk/airbridge_flutter_sdk.dart';
@@ -190,7 +190,7 @@ class _customFormState extends State<customForm> {
                                 showDialog(
                                     context: context,
                                     builder: (BuildContext context) {
-                                      return CheckMoveToSettings();
+                                      return CheckMoveToPhotoSettings();
                                     });
                               }
                             }, // 갤러리에서 사진 가져오고
@@ -229,7 +229,7 @@ class _customFormState extends State<customForm> {
                                 showDialog(
                                     context: context,
                                     builder: (BuildContext context) {
-                                      return CheckMoveToSettings();
+                                      return CheckMoveToPhotoSettings();
                                     });
                               }
                             }, // 카메라로 사진 찍기

--- a/lib/page/form.dart
+++ b/lib/page/form.dart
@@ -176,7 +176,7 @@ class _customFormState extends State<customForm> {
                           OutlinedButton(
                             onPressed: () async {
                               var status = await Permission.photos.request();
-                              if (await status.isGranted) {
+                              if (status.isGranted) {
                                 // Either the permission was already granted before or the user just granted it.
                                 // 이전에 권한에 동의를 했거나, 방금 유저가 권한을 허용한 경우 : 사진 선택하고, bottom sheet 빠져나온 뒤, snackbar를 보여준다.
                                 print("권한을 허용했습니다.");

--- a/lib/page/formchange.dart
+++ b/lib/page/formchange.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dio/dio.dart' as dio;
 
@@ -24,6 +25,7 @@ import 'package:extended_image/extended_image.dart';
 import '../style/colorstyles.dart';
 import '../utils/price_utils.dart';
 import 'app.dart';
+import 'checkmovetophotosettings.dart';
 import 'imageuploader.dart';
 
 class customFormChange extends StatefulWidget {
@@ -138,7 +140,7 @@ class _customFormChangeState extends State<customFormChange> {
 
   List<XFile>? imageFileList = []; // 갤러리에서 가져온 사진을 여기에 넣는다.
 
-  void selectImagesFromGallery() async {
+  Future selectImagesFromGallery() async {
     final List<XFile>? selectedImagesFromGallery =
         await imagePickerFromGallery.pickMultiImage();
     setState(() {});
@@ -162,7 +164,7 @@ class _customFormChangeState extends State<customFormChange> {
     setState(() {});
   }
 
-  void selectImagesFromCamera() async {
+  Future selectImagesFromCamera() async {
     final XFile? selectedImageFromCamera =
         await imagePickerFromCamera.pickImage(source: ImageSource.camera);
     setState(() {});
@@ -225,26 +227,25 @@ class _customFormChangeState extends State<customFormChange> {
                       Column(
                         children: [
                           OutlinedButton(
-                            onPressed: () {
-                              selectImagesFromGallery();
-                              Navigator.pop(context);
-
-                              const snackBar = SnackBar(
-                                content: Text(
-                                  "사진은 3장까지 업로드할 수 있습니다!",
-                                  style: TextStyle(color: Colors.white),
-                                ),
-                                // backgroundColor: Colors.black,
-                                duration: Duration(milliseconds: 2000),
-                                behavior: SnackBarBehavior.floating,
-                                elevation: 50,
-                                shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.all(
-                                  Radius.circular(5),
-                                )),
-                              );
-                              ScaffoldMessenger.of(context)
-                                  .showSnackBar(snackBar);
+                            onPressed: () async {
+                              var status = await Permission.photos.request();
+                              if (status.isGranted) {
+                                // Either the permission was already granted before or the user just granted it.
+                                // 이전에 권한에 동의를 했거나, 방금 유저가 권한을 허용한 경우 : 사진 선택하고, bottom sheet 빠져나온 뒤, snackbar를 보여준다.
+                                print("권한을 허용했습니다.");
+                                await selectImagesFromGallery();
+                                Navigator.pop(context);
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                    MySnackBar("사진은 3장까지 업로드할 수 있습니다!"));
+                              } else {
+                                // 권한을 허용하지 않은 경우 : 설정으로 이동해서 권한 허용을 요청하는 alert dialog 띄우기
+                                print("권한을 허용하지 않았습니다.");
+                                showDialog(
+                                    context: context,
+                                    builder: (BuildContext context) {
+                                      return CheckMoveToPhotoSettings();
+                                    });
+                              }
                             }, // 갤러리에서 사진 가져오고
                             style: OutlinedButton.styleFrom(
                                 padding: const EdgeInsets.all(20),
@@ -267,8 +268,23 @@ class _customFormChangeState extends State<customFormChange> {
                       Column(
                         children: [
                           OutlinedButton(
-                            onPressed: () {
-                              selectImagesFromCamera();
+                            onPressed: () async {
+                              var status = await Permission.camera.request();
+                              if (status.isGranted) {
+                                // Either the permission was already granted before or the user just granted it.
+                                // 이전에 권한에 동의를 했거나, 방금 유저가 권한을 허용한 경우 : 사진 선택하고, bottom sheet 빠져나온 뒤, snackbar를 보여준다.
+                                print("권한을 허용했습니다.");
+                                await selectImagesFromCamera();
+                                Navigator.pop(context);
+                              } else {
+                                // 권한을 허용하지 않은 경우 : 설정으로 이동해서 권한 허용을 요청하는 alert dialog 띄우기
+                                print("권한을 허용하지 않았습니다.");
+                                showDialog(
+                                    context: context,
+                                    builder: (BuildContext context) {
+                                      return CheckMoveToPhotoSettings();
+                                    });
+                              }
                             }, // 카메라로 사진 찍기
                             style: OutlinedButton.styleFrom(
                                 padding: const EdgeInsets.all(20),

--- a/lib/page/splash/splash.dart
+++ b/lib/page/splash/splash.dart
@@ -23,7 +23,7 @@ class _SplashState extends State<Splash> {
     SharedPreferences prefs = await SharedPreferences
         .getInstance(); // getInstance로 기기 내 shared_prefs 객체를 가져온다.
 
-    //prefs.clear();
+    // prefs.clear();
     // TODO : 닉네임 설정 완료 여부를 확인하는 API를 호출하는 부분
     bool hasToken = false;
     String? userToken = prefs.getString("userToken");
@@ -52,7 +52,7 @@ class _SplashState extends State<Splash> {
       } else if (list['code'] == 300 || list['code'] == 404) {
         print("코드가 ${list['code']}입니다. 약관동의 화면으로 리다이렉트합니다.");
         Navigator.pushNamedAndRemoveUntil(
-              context, '/termscheck', (route) => false);
+            context, '/termscheck', (route) => false);
       } else {
         print("서버 에러가 발생하였습니다. 로그인 화면으로 리다이렉트합니다.");
         Navigator.pushNamedAndRemoveUntil(context, '/login', (route) => false);

--- a/lib/page/termscheck.dart
+++ b/lib/page/termscheck.dart
@@ -382,8 +382,8 @@ class _TermsCheckState extends State<TermsCheck> {
 
   Future<bool> checkIfPermissionGranted() async {
     Map<Permission, PermissionStatus> statuses = await [
-      Permission.camera,
-      Permission.storage,
+      // Permission.camera,
+      // Permission.storage,
       Permission.location,
       // Permission.locationAlways,
       Permission.locationWhenInUse


### PR DESCRIPTION
[CB-233]
feature/photoPermission_CB233 브랜치를 develop 브랜치에 병합

회원가입 과정 중 가장 처음에 로그인 버튼을 누르자마자 나타나는 카메라와 갤러리 권한을 제거하고, 
폼(form.dart, formchange.dart)에서 사진을 고르려고 할 때 카메라와 갤러리 권한을 묻는다.

권한을 허용하는 경우에는 image picker에 의해 갤러리에서 사진을 고를 수 있거나 사진을 찍을 수 있다. 
권한을 허용하지 않는 경우에는 alert dialog가 나와서 설정으로 이동해서 권한을 변경해달라고 요청한다.
    >> alert dialog에서 취소를 누르는 경우, 계속해서 폼을 작성할 수 있게 된다.
    >> alert dialog에서 설정으로 이동하기 버튼을 누르는 경우, 설정으로 이동한다.
         (설정으로 이동해서 권한 허용 설정을 하고 다시 앱을 들어가면 다시 스플래시가 나오고 홈 화면으로 이동한다.)

권한을 허용하지 않고, 앱을 나간 후에 앱에 다시 들어와서 사진을 선택하려고 하면, alert dialog가 나와서 설정으로 가서 권한을 허용해달라고 요청한다.

[CB-233]: https://chocobread.atlassian.net/browse/CB-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ