### PR TITLE
[CB-230] 탈퇴하기 전에 탈퇴를 확인하는 dialog 추가 + 로그인 화면의 불필요한 버튼 제거하기

### DIFF
--- a/lib/page/checkresign.dart
+++ b/lib/page/checkresign.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+
+import 'package:airbridge_flutter_sdk/airbridge_flutter_sdk.dart';
+import 'package:flutter/material.dart';
+import 'package:jwt_decode/jwt_decode.dart';
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:http/http.dart' as http;
+
+import 'login.dart';
+
+class CheckResign extends StatefulWidget {
+  CheckResign({Key? key}) : super(key: key);
+
+  @override
+  State<CheckResign> createState() => _CheckResignState();
+}
+
+class _CheckResignState extends State<CheckResign> {
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text("정말 탈퇴하시겠습니까?"),
+      content: const Text("탈퇴하시면 N빵을 사용할 수 없습니다."),
+      actions: [
+        TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+            child: const Text("취소")),
+        TextButton(
+            onPressed: () async {
+              // int count = 0;
+              // Navigator.of(context).popUntil((_) => count++ >= 2);
+              Airbridge.event.send(SignOutEvent());
+              await resign();
+              Navigator.pushAndRemoveUntil(
+                  context,
+                  MaterialPageRoute(builder: (BuildContext context) => Login()),
+                  (route) => false);
+            },
+            child: const Text("확인"))
+      ],
+    );
+  }
+
+  //kakao apple resign api
+  Future<void> resign() async {
+    final prefs = await SharedPreferences.getInstance();
+    String? token = prefs.getString("userToken");
+
+    if (token != null) {
+      Map<String, dynamic> payload = Jwt.parseJwt(token);
+      print('payload value is ${payload}');
+
+      String provider = payload['provider'].toString();
+      print("provider is ${provider} on resign api");
+
+      if (provider == "kakao") {
+        provider = "kakaosdk";
+        try {
+          await UserApi.instance.unlink();
+          print('연결 끊기 성공, SDK에서 토큰 삭제');
+        } catch (error) {
+          print('연결 끊기 실패 $error');
+        }
+      }
+
+      String tmpUrl =
+          'https://www.chocobread.shop/auth/' + provider + '/signout';
+      print("tmpUrl value is ${tmpUrl}");
+      var url = Uri.parse(
+        tmpUrl,
+      );
+      var response = await http.delete(url, headers: {
+        'Authorization': token,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      });
+      String responseBody = utf8.decode(response.bodyBytes);
+      Map<String, dynamic> list = jsonDecode(responseBody);
+      prefs.remove("userToken");
+      print("prefs setting done");
+      print(list);
+      //Map<String, dynamic> list = jsonDecode(responseBody);
+      // if (list.length == 0) {
+      //   print("length of list is 0");
+      // } else {
+      //   print(list);
+      // }
+    }
+  }
+}

--- a/lib/page/login.dart
+++ b/lib/page/login.dart
@@ -285,14 +285,11 @@ class _LoginState extends State<Login> {
                 prefs.setString("userLocation", "위치를 알 수 없는 사용자입니다");
                 print(
                     "curLocation을 db에서 가져오려했으나 null입니다. 현재 로컬 스토리지에 저장된 curLocation은 ${prefs.getString('userLocation')}입니다");
-              }
-              else{
+              } else {
                 prefs.setString("userLocation", list['result']['addr']);
                 print(
                     "curLocation을 db에서 가져왔습니다. 현재 로컬 스토리지에 저장된 curLocation은 ${prefs.getString('userLocation')}입니다");
               }
-              
-              
             } else {
               print("token is null");
             }
@@ -495,19 +492,10 @@ class _LoginState extends State<Login> {
               const SizedBox(
                 height: 10,
               ),
-              _kakaologoutSDK(),
-              const SizedBox(
-                height: 10,
-              ),
-              _kakaologin(),
-              const SizedBox(
-                height: 10,
-              ),
               _applelogin(),
               const SizedBox(
                 height: 10,
               ),
-              _home(),
             ],
           ),
         ),
@@ -517,19 +505,14 @@ class _LoginState extends State<Login> {
 
   @override
   Widget build(BuildContext context) {
-    Airbridge.Airbridge.state.setUser(
-        Airbridge.User(
-          id: 'tester',
-          email: 'tester@ab180.co',
-          alias: {
-            'alias_key': 'alias_value',
-          },
-          attributes: {
-            'provider': 'attr_value',
-            'curLoaction3' : 'location_value'
-          },  
-        )
-    );
+    Airbridge.Airbridge.state.setUser(Airbridge.User(
+      id: 'tester',
+      email: 'tester@ab180.co',
+      alias: {
+        'alias_key': 'alias_value',
+      },
+      attributes: {'provider': 'attr_value', 'curLoaction3': 'location_value'},
+    ));
     return Scaffold(
       extendBodyBehindAppBar: true, // 앱 바 위에까지 침범 허용
       appBar: _appbarWidget(),

--- a/lib/page/mypage.dart
+++ b/lib/page/mypage.dart
@@ -4,6 +4,7 @@ import 'package:chocobread/constants/sizes_helper.dart';
 import 'dart:convert';
 
 import 'package:chocobread/page/app.dart';
+import 'package:chocobread/page/checkresign.dart';
 import 'package:chocobread/page/home.dart';
 import 'package:chocobread/page/kakaoLogout.dart';
 import 'package:chocobread/page/login.dart';
@@ -156,14 +157,12 @@ class _MyPageState extends State<MyPage> {
                                   ),
                               onPressed: () async {
                                 print("탈퇴하기 버튼이 눌렸습니다.");
-                                Airbridge.event.send(SignOutEvent());
-                                await resign();
-                                Navigator.pushAndRemoveUntil(
-                                    context,
-                                    MaterialPageRoute(
-                                        builder: (BuildContext context) =>
-                                            Login()),
-                                    (route) => false);
+                                showDialog(
+                                    context: context,
+                                    builder: (BuildContext context) {
+                                      return CheckResign();
+                                    });
+                                
                                 // 로그아웃을 하면 이동하는 페이지 넣기
                                 // Navigator.push(context, MaterialPageRoute(
                                 //     builder: (BuildContext context) {
@@ -591,52 +590,6 @@ class _MyPageState extends State<MyPage> {
       var response = await http.get(url);
       String responseBody = utf8.decode(response.bodyBytes);
       print(responseBody);
-      //Map<String, dynamic> list = jsonDecode(responseBody);
-      // if (list.length == 0) {
-      //   print("length of list is 0");
-      // } else {
-      //   print(list);
-      // }
-    }
-  }
-
-  //kakao apple resign api
-  Future<void> resign() async {
-    final prefs = await SharedPreferences.getInstance();
-    String? token = prefs.getString("userToken");
-
-    if (token != null) {
-      Map<String, dynamic> payload = Jwt.parseJwt(token);
-      print('payload value is ${payload}');
-
-      String provider = payload['provider'].toString();
-      print("provider is ${provider} on resign api");
-
-      if (provider == "kakao") {
-        provider = "kakaosdk";
-        try {
-          await UserApi.instance.unlink();
-          print('연결 끊기 성공, SDK에서 토큰 삭제');
-        } catch (error) {
-          print('연결 끊기 실패 $error');
-        }
-      }
-
-      String tmpUrl =
-          'https://www.chocobread.shop/auth/' + provider + '/signout';
-      print("tmpUrl value is ${tmpUrl}");
-      var url = Uri.parse(
-        tmpUrl,
-      );
-      var response = await http.delete(url, headers: {
-        'Authorization': token,
-        'Content-Type': 'application/x-www-form-urlencoded'
-      });
-      String responseBody = utf8.decode(response.bodyBytes);
-      Map<String, dynamic> list = jsonDecode(responseBody);
-      prefs.remove("userToken");
-      print("prefs setting done");
-      print(list);
       //Map<String, dynamic> list = jsonDecode(responseBody);
       // if (list.length == 0) {
       //   print("length of list is 0");


### PR DESCRIPTION
## [CB-230]

feature/resignDialog 브랜치를 develop 브랜치에 병합

### 탈퇴하기 dialog
- 탈퇴하기 버튼을 누르면, 진짜 탈퇴를 하겠냐고 확인하는 dialog 가 뜬다.
    - 취소를 누르면 dialog가 pop된다.
    - 확인을 누르면 탈퇴가 되고 로그인 화면으로 이동한다.

### 로그인 화면 정리
- 불필요한 기존의 웹뷰 카카오 로그인, 카카오 SDK 로그아웃, 로그인 없이 둘러보기 버튼 모두 로그인 화면에서 제거



[CB-230]: https://chocobread.atlassian.net/browse/CB-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ