### PR TITLE
[CB-284] detail에 있는 이미지 비율 조정 + 이미지 크게 보기

### DIFF
--- a/lib/page/detail.dart
+++ b/lib/page/detail.dart
@@ -28,6 +28,7 @@ import 'blockuser.dart';
 import 'checkdeletecomment.dart';
 import 'checkdeletecontents.dart';
 import 'comments.dart';
+import 'detailimageview.dart';
 import 'done.dart';
 
 String title = "";
@@ -280,7 +281,7 @@ class _DetailContentViewState extends State<DetailContentView> {
         //     icon: const Icon(
         //       Icons.share,
         //       color: Colors.white,
-            // )),
+        // )),
         _popupMenuButtonSelector(),
         // IconButton(
         //     onPressed: () {},
@@ -340,7 +341,7 @@ class _DetailContentViewState extends State<DetailContentView> {
           cache: true,
           enableLoadState: true,
           width: size.width,
-          fit: BoxFit.fill,
+          fit: BoxFit.fitWidth,
         );
       }).toList();
     } else {
@@ -357,7 +358,8 @@ class _DetailContentViewState extends State<DetailContentView> {
   }
 
   Widget _makeSliderImage() {
-    return Container(
+    return GestureDetector(
+      // 이미지를 클릭하면 전체 화면에서 상세하게 확인할 수 있다.
       child: Stack(
         // 이미지와 indicator가 겹치게 만들어야 하므로
         children: [
@@ -391,6 +393,26 @@ class _DetailContentViewState extends State<DetailContentView> {
             bottom: 0,
             left: 0,
             right: 0,
+            child: Container(
+              // 사진 위에 그래디언트 container stack으로 추가해서 indicator 명확하게 보이도록 처리
+              width: 10.0,
+              height: 50.0,
+              padding:
+                  const EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),
+              decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                      begin: Alignment.bottomCenter,
+                      end: Alignment.topCenter,
+                      colors: [
+                    Colors.black.withOpacity(0.2),
+                    Colors.black.withOpacity(0.001),
+                  ])),
+            ),
+          ),
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: imgList.map((map) {
@@ -413,6 +435,17 @@ class _DetailContentViewState extends State<DetailContentView> {
           ),
         ],
       ),
+      onTap: () {
+        if (widget.data["DealImages"].length == 0) {
+          // 사진이 없는 경우, 사진을 눌러도 아무 일도 발생하지 않는다.
+          return null;
+        } else {
+          Navigator.push(context,
+              MaterialPageRoute(builder: (BuildContext context) {
+            return DetailImageView(imgList: imgList,);
+          }));
+        }
+      },
     );
   }
 

--- a/lib/page/detail.dart
+++ b/lib/page/detail.dart
@@ -442,7 +442,7 @@ class _DetailContentViewState extends State<DetailContentView> {
         } else {
           Navigator.push(context,
               MaterialPageRoute(builder: (BuildContext context) {
-            return DetailImageView(imgList: imgList,);
+            return DetailImageView(imgList: imgList, currentIndex: _current);
           }));
         }
       },

--- a/lib/page/detailimageview.dart
+++ b/lib/page/detailimageview.dart
@@ -5,7 +5,9 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 class DetailImageView extends StatefulWidget {
   List<Map<String, String>> imgList;
-  DetailImageView({Key? key, required this.imgList}) : super(key: key);
+  int currentIndex;
+  DetailImageView({Key? key, required this.imgList, required this.currentIndex})
+      : super(key: key);
 
   @override
   State<DetailImageView> createState() => _DetailImageViewState();
@@ -15,9 +17,15 @@ class _DetailImageViewState extends State<DetailImageView> {
   late int _current; // _current 변수 선언
 
   @override
+  void initState() {
+    super.initState();
+    _current = widget.currentIndex; // _current 인덱스를 0으로 초기화
+  }
+
+  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _current = 0; // _current 인덱스를 0으로 초기화
+    // _current = widget.currentIndex; // _current 인덱스를 0으로 초기화
   }
 
   PreferredSizeWidget _appBarWidget() {
@@ -62,7 +70,7 @@ class _DetailImageViewState extends State<DetailImageView> {
               items: _itemsForSliderImage(),
               options: CarouselOptions(
                   height: double.infinity,
-                  initialPage: 0, //첫번째 페이지
+                  initialPage: widget.currentIndex, // 첫번째 페이지는 detail에서 유저가 클릭해서 들어온 페이지
                   enableInfiniteScroll: false, // 무한 스크롤 방지
                   viewportFraction: 1, // 전체 화면 사용
                   onPageChanged: (firstIndex, reason) {

--- a/lib/page/detailimageview.dart
+++ b/lib/page/detailimageview.dart
@@ -1,0 +1,111 @@
+import 'package:carousel_slider/carousel_slider.dart';
+import 'package:extended_image/extended_image.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+class DetailImageView extends StatefulWidget {
+  List<Map<String, String>> imgList;
+  DetailImageView({Key? key, required this.imgList}) : super(key: key);
+
+  @override
+  State<DetailImageView> createState() => _DetailImageViewState();
+}
+
+class _DetailImageViewState extends State<DetailImageView> {
+  late int _current; // _current 변수 선언
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _current = 0; // _current 인덱스를 0으로 초기화
+  }
+
+  PreferredSizeWidget _appBarWidget() {
+    return AppBar(
+      leading: IconButton(
+          // Navigator 사용시 보통 자동으로 생성되나, 기타 처리 필요하므로 따로 생성
+          onPressed: () {
+            Navigator.pop(context);
+          },
+          icon: const FaIcon(
+            FontAwesomeIcons.x,
+            color: Colors.white,
+            size: 20,
+          )),
+      centerTitle: false,
+      titleSpacing: 0,
+      elevation: 0,
+      bottomOpacity: 0,
+      backgroundColor: Colors.transparent,
+      automaticallyImplyLeading: true,
+    );
+  }
+
+  List<Widget> _itemsForSliderImage() {
+    return widget.imgList.map((map) {
+      return ExtendedImage.network(
+        map["_url"].toString(),
+        cache: true,
+        enableLoadState: true,
+        width: double.infinity,
+        fit: BoxFit.fitWidth,
+      );
+    }).toList();
+  }
+
+  Widget _bodyWidget() {
+    return SafeArea(
+      child: Column(
+        children: [
+          Expanded(
+            child: CarouselSlider(
+              items: _itemsForSliderImage(),
+              options: CarouselOptions(
+                  height: double.infinity,
+                  initialPage: 0, //첫번째 페이지
+                  enableInfiniteScroll: false, // 무한 스크롤 방지
+                  viewportFraction: 1, // 전체 화면 사용
+                  onPageChanged: (firstIndex, reason) {
+                    setState(() {
+                      _current = firstIndex;
+                    });
+                    print(firstIndex);
+                  }),
+            ),
+          ),
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: widget.imgList.map((map) {
+                return Container(
+                  width: 10.0,
+                  height: 10.0,
+                  margin: const EdgeInsets.symmetric(
+                      vertical: 8.0, horizontal: 4.0),
+                  decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: _current == int.parse(map["id"].toString())
+                          // (Theme.of(context).brightness == Brightness.dark
+                          ? Colors.white
+                          : Colors.white.withOpacity(0.4)),
+                );
+              }).toList(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: _appBarWidget(),
+      body: _bodyWidget(),
+    );
+  }
+}


### PR DESCRIPTION
## [CB-284] 

feature/imageProportion_CB-284 브랜치를 develop 브랜치에 병합

- detail.dart에 있는 이미지의 BoxFit 조건을 width가 채워지도록 처리
- indicator가 보이도록 linear gradient를 가진 container를 stack에 추가해줌
- detail.dart에 있는 이미지를 클릭하면 이미지만 볼 수 있도록 처리됨
- 탭한 이미지부터 보여주도록 처리 (순서 보존)

[CB-284]: https://chocobread.atlassian.net/browse/CB-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ