### PR TITLE
[CB-291] 이미지 크게보기 화면에서의 incorrect use of parentwidget 버그 해결

### DIFF
--- a/lib/page/detailimageview.dart
+++ b/lib/page/detailimageview.dart
@@ -70,7 +70,8 @@ class _DetailImageViewState extends State<DetailImageView> {
               items: _itemsForSliderImage(),
               options: CarouselOptions(
                   height: double.infinity,
-                  initialPage: widget.currentIndex, // 첫번째 페이지는 detail에서 유저가 클릭해서 들어온 페이지
+                  initialPage:
+                      widget.currentIndex, // 첫번째 페이지는 detail에서 유저가 클릭해서 들어온 페이지
                   enableInfiniteScroll: false, // 무한 스크롤 방지
                   viewportFraction: 1, // 전체 화면 사용
                   onPageChanged: (firstIndex, reason) {
@@ -81,27 +82,22 @@ class _DetailImageViewState extends State<DetailImageView> {
                   }),
             ),
           ),
-          Positioned(
-            bottom: 0,
-            left: 0,
-            right: 0,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: widget.imgList.map((map) {
-                return Container(
-                  width: 10.0,
-                  height: 10.0,
-                  margin: const EdgeInsets.symmetric(
-                      vertical: 8.0, horizontal: 4.0),
-                  decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: _current == int.parse(map["id"].toString())
-                          // (Theme.of(context).brightness == Brightness.dark
-                          ? Colors.white
-                          : Colors.white.withOpacity(0.4)),
-                );
-              }).toList(),
-            ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: widget.imgList.map((map) {
+              return Container(
+                width: 10.0,
+                height: 10.0,
+                margin:
+                    const EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),
+                decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: _current == int.parse(map["id"].toString())
+                        // (Theme.of(context).brightness == Brightness.dark
+                        ? Colors.white
+                        : Colors.white.withOpacity(0.4)),
+              );
+            }).toList(),
           ),
         ],
       ),


### PR DESCRIPTION
## [CB-291]

bug/incorrectParentUsage_CB-291 브랜치를 develop 브랜치에 병합

- 이미지 크게 보기에서 incorrect use of parentWidget 에러가 났음
-> Positioned Widget이 Column안에 있어서 문제가 되는 것이었음
-> Positioned Widget을 제거해서 해결함

[CB-291]: https://chocobread.atlassian.net/browse/CB-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ