### PR TITLE
[CB-302] dataForSharedUser 초기화가 안되는 오류, Map == {} 오류 수정

### DIFF
--- a/lib/page/splash/splash.dart
+++ b/lib/page/splash/splash.dart
@@ -39,28 +39,42 @@ class _SplashState extends State<Splash> {
   void initState() {
     super.initState();
     contentsRepository = ContentsRepository();
-    datasForSharedUser = [];
-    dataForSharedUser = {};
     checkStatus();
   }
 
   void _handleDynamicLink(Uri deepLink) async {
+    datasForSharedUser = [];
+    dataForSharedUser = {};
+    print(deepLink);
     String? code = deepLink.queryParameters['id'];
     print(int.parse(code!));
     if (code != null) {
       print('deep link 로부터 받은 코드는 ${code}입니다.');
       print("loadContents on splash");
+      final prefs = await SharedPreferences.getInstance();
+      String range = prefs.getString('range') ?? 'loc2';
+      String location = prefs.getString(range) ?? "기본값";
+      String tmpUrl =
+        'https://www.chocobread.shop/deals/all/' + range + '/' + location; // 
+      var url = Uri.parse(
+        tmpUrl,
+      );
+      var tmp = List<Map<String, dynamic>>.empty(growable: true);
+
       datasForSharedUser = await contentsRepository.loadContentsFromLocation();
       print("loadContents done");
       print('data for share user = ${datasForSharedUser}');
 
       for (int i = 0; i < datasForSharedUser.length; i++) {
+        print("API id : ${datasForSharedUser[i]["id"]} || ${int.parse(code)}");
         if (datasForSharedUser[i]["id"] == int.parse(code)) {
           dataForSharedUser = datasForSharedUser[i];
           print("[*] dataForSharedUSer : $dataForSharedUser");
         }
       }
-      if (dataForSharedUser == {}) {
+
+      print("Deep link after For Loop ${dataForSharedUser}");
+      if (dataForSharedUser.isEmpty) {
         // 공유받은 거래가 존재하지 않는 경우 : 홈 화면으로 이동
         print("공유받은 거래가 존재하지 않습니다. 홈 화면으로 이동합니다.");
         Get.offAll(const App());
@@ -122,7 +136,6 @@ class _SplashState extends State<Splash> {
   }
 
   void checkStatus() async {
-    await getDeepLink();
     SharedPreferences prefs = await SharedPreferences
         .getInstance(); // getInstance로 기기 내 shared_prefs 객체를 가져온다.
 
@@ -137,6 +150,7 @@ class _SplashState extends State<Splash> {
     String? userToken = prefs.getString("userToken");
 
     if (userToken != null) {
+      await getDeepLink();
       Map<String, dynamic> payload = Jwt.parseJwt(userToken);
 
       String userId = payload['id'].toString();

--- a/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux
@@ -1,1 +1,1 @@
-/Users/chaeeunseo/.pub-cache/hosted/pub.dartlang.org/flutter_secure_storage_linux-1.1.1/
+/Users/kwontaehyun/flutter/.pub-cache/hosted/pub.dartlang.org/flutter_secure_storage_linux-1.1.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
@@ -1,1 +1,1 @@
-/Users/chaeeunseo/.pub-cache/hosted/pub.dartlang.org/path_provider_linux-2.1.7/
+/Users/kwontaehyun/flutter/.pub-cache/hosted/pub.dartlang.org/path_provider_linux-2.1.7/

--- a/linux/flutter/ephemeral/.plugin_symlinks/share_plus_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/share_plus_linux
@@ -1,1 +1,1 @@
-/Users/chaeeunseo/.pub-cache/hosted/pub.dartlang.org/share_plus_linux-3.0.0/
+/Users/kwontaehyun/flutter/.pub-cache/hosted/pub.dartlang.org/share_plus_linux-3.0.0/

--- a/linux/flutter/ephemeral/.plugin_symlinks/shared_preferences_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/shared_preferences_linux
@@ -1,1 +1,1 @@
-/Users/chaeeunseo/.pub-cache/hosted/pub.dartlang.org/shared_preferences_linux-2.1.1/
+/Users/kwontaehyun/flutter/.pub-cache/hosted/pub.dartlang.org/shared_preferences_linux-2.1.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
@@ -1,1 +1,1 @@
-/Users/chaeeunseo/.pub-cache/hosted/pub.dartlang.org/url_launcher_linux-3.0.1/
+/Users/kwontaehyun/flutter/.pub-cache/hosted/pub.dartlang.org/url_launcher_linux-3.0.1/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -587,21 +587,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.11"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -664,7 +664,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   path_drawing:
     dependency: transitive
     description:
@@ -949,7 +949,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -970,21 +970,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
# feature/linkEmptyMapError_CB-302에서 오류수정

 
## dataForSharedUser 초기화가 안되는 오류

    datasForSharedUser = [];
    dataForSharedUser = {};
를 initState()에서만 해줘서 스플래쉬를 거치지 않고 들어오면 초기화가 안되서 해당 글이 있다고 판단.

## 해당 거래가 존재하지 않는 경우에도 존재한다고 판단하여 null 오류 발생

dataForSharedUser == {}  (오류)
dataForSharedUser.isEmpty (수정)

## getDeepLink() 위치 변경
토큰이 있을때만 DeepLink로 연결시키고 없을때(로그인이 안됐을때)는 로그인 화면으로 연결