### PR TITLE
[CB-331] 플레이스토어에서 다운로드 받은 버전의 경우, 이벤트 팝업의 버튼이 길어지는 버그 fix

### DIFF
--- a/lib/page/event/event_popup.dart
+++ b/lib/page/event/event_popup.dart
@@ -80,7 +80,10 @@ class _EventPopUpState extends State<EventPopUp> {
                           topLeft: Radius.circular(10),
                           topRight: Radius.circular(10)),
                       child: widget.eventPopUpImage)),
-              IntrinsicHeight(
+              SizedBox(
+                // 플레이스토어에서 다운로드 받은 경우 : 버튼의 높이가 길어지는 문제를 해결하기 위해 높이를 제한함
+                height: 40,
+                // IntrinsicHeight(
                 // vertical divider 를 추가하기 위해 필요
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceEvenly,


### PR DESCRIPTION
## [CB-331]

bug/eventPopUpButton_CB-331 브랜치를 develop 브랜치에 병합

- 플레이스토어에서 다운로드 받은 버전의 경우, 이벤트 팝업의 버튼이 길어지는 버그 fix

[CB-331]: https://chocobread.atlassian.net/browse/CB-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ