### PR TITLE
[CB-335]

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -279,7 +279,7 @@ SPEC CHECKSUMS:
   FirebaseDynamicLinks: 311bb05788180e31a502bd0d413215413a4b3357
   FirebaseInstallations: 0a115432c4e223c5ab20b0dbbe4cbefa793a0e8e
   FirebaseMessaging: 4e220eddd356181469ba2ec5f7d5fafbc2312841
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec

--- a/lib/page/event/event_popup.dart
+++ b/lib/page/event/event_popup.dart
@@ -33,123 +33,66 @@ class _EventPopUpState extends State<EventPopUp> {
   @override
   Widget build(BuildContext context) {
     print("event_popup에 들어오는 eventPopUpImage : ${widget.eventPopUpImage}");
-    return Dialog(
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(10))),
-      child: Wrap(
-        // column의 높이를 content에 맞추기 위한 것
-        children: [
-          Column(
-            children: [
-              // 이벤트 팝업 이미지
-              GestureDetector(
-                  onTap: () async {
-                    print("[*] popup clicked!");
-                    if (widget.type == "Detail") {
-                      print("[*] detail 화면으로 이동합니다!");
-                      var temp =
-                          await loadContentByDealId(int.parse(widget.target));
-                      print("[*] detail 화면으로 보내지는 data : ${temp}");
-                      Get.to(() => DetailContentView(
-                            data: temp,
-                            isFromHome: true,
-                          ));
-                    } else if (widget.type == "Intro") {
-                      Get.to(() => ServiceInfo());
-                    } else if (widget.type == "LinkIn") {
-                      // 인 앱 웹뷰를 띄우고 싶은 경우
-                      Get.to(() => WebViewIn(mylink: widget.target));
-                    } else if (widget.type == "LinkOut") {
-                      // 외부 브라우저로 띄우고 싶은 경우
-                      if (await canLaunchUrl(Uri.parse(widget.target))) {
-                        await launchUrl(Uri.parse(widget.target),
-                            mode: LaunchMode.externalApplication);
-                      } else {
-                        throw '인 앱 웹뷰를 띄울 수 없습니다! : ${widget.target}';
-                      }
-                    } else if (widget.type == "EventPage") {
-                      // 이벤트 페이지로 이동
-                      Get.to(() => const EventPage());
-                    } else {
-                      Get.to(const App());
-                    }
-                  },
-                  child: ClipRRect(
-                      // 이미지 모서리를 둥글게 처리하기
-                      borderRadius: const BorderRadius.only(
-                          topLeft: Radius.circular(10),
-                          topRight: Radius.circular(10)),
-                      child: widget.eventPopUpImage)),
-              SizedBox(
-                // 플레이스토어에서 다운로드 받은 경우 : 버튼의 높이가 길어지는 문제를 해결하기 위해 높이를 제한함
-                height: 40,
-                // IntrinsicHeight(
-                // vertical divider 를 추가하기 위해 필요
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  children: [
-                    Expanded(
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.translucent,
-                        // behavior: HitTestBehavior.opaque,
-                        onTap: () async {
-                          // 다시보지 않기를 누르면
-                          SharedPreferences prefs =
-                              await SharedPreferences.getInstance();
-                          prefs.setInt('recentId', widget.id);
-                          Navigator.of(context).pop();
-                        },
-                        child: const Center(
-                            child: Expanded(
-                                child: Padding(
-                          padding: EdgeInsets.all(8.0),
-                          child: Text(
-                            "다시보지 않기",
-                            style: TextStyle(color: Colors.grey),
-                          ),
-                        ))),
-                      ),
-                    ),
-                    VerticalDivider(
-                      color: Colors.grey.withOpacity(0.5),
-                      thickness: 0.6,
-                    ),
-                    Expanded(
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.translucent,
-                        // behavior: HitTestBehavior.opaque,
-                        onTap: () async {
-                          if (widget.type == "Detail") {
-                            print("[*] detail 화면으로 이동합니다!");
-                            var temp = await loadContentByDealId(
-                                int.parse(widget.target));
-                            print("[*] detail 화면으로 보내지는 data : ${temp}");
-                            Get.to(() => DetailContentView(
-                                  data: temp,
-                                  isFromHome: true,
-                                ));
-                          } else {
-                            Get.to(() => const App());
-                          }
-                        },
-                        child: const Center(
-                          child: Expanded(
-                              child: Text(
-                            "자세히 보기",
-                            style: TextStyle(
-                              color: ColorStyle.mainColor,
-                            ),
-                          )),
-                        ),
-                      ),
-                    )
-                  ],
-                ),
-              )
-            ],
-          ),
-        ],
-      ),
+    return AlertDialog(
+      content: GestureDetector(
+          onTap: () async {
+            print("[*] popup clicked!");
+            if (widget.type == "Detail") {
+              print("[*] detail 화면으로 이동합니다!");
+              var temp = await loadContentByDealId(int.parse(widget.target));
+              print("[*] detail 화면으로 보내지는 data : ${temp}");
+              Get.to(() => DetailContentView(
+                    data: temp,
+                    isFromHome: true,
+                  ));
+            } else if (widget.type == "Intro") {
+              Get.to(() => ServiceInfo());
+            } else if (widget.type == "LinkIn") {
+              // 인 앱 웹뷰를 띄우고 싶은 경우
+              Get.to(() => WebViewIn(mylink: widget.target));
+            } else if (widget.type == "LinkOut") {
+              // 외부 브라우저로 띄우고 싶은 경우
+              if (await canLaunchUrl(Uri.parse(widget.target))) {
+                await launchUrl(Uri.parse(widget.target),
+                    mode: LaunchMode.externalApplication);
+              } else {
+                throw '인 앱 웹뷰를 띄울 수 없습니다! : ${widget.target}';
+              }
+            } else if (widget.type == "EventPage") {
+              // 이벤트 페이지로 이동
+              Get.to(() => const EventPage());
+            } else {
+              Get.to(const App());
+            }
+          },
+          child: widget.eventPopUpImage),
+      // const Text("이벤트 popup 테스트"),
+      actionsOverflowButtonSpacing: 20,
+      actions: [
+        TextButton(
+            onPressed: () async {
+              // 다시보지 않기를 누르면
+              SharedPreferences prefs = await SharedPreferences.getInstance();
+              prefs.setInt('recentId', widget.id);
+              Navigator.of(context).pop();
+            },
+            child: const Text("다시보지 않기")),
+        TextButton(
+            onPressed: () async {
+              if (widget.type == "Detail") {
+                print("[*] detail 화면으로 이동합니다!");
+                var temp = await loadContentByDealId(int.parse(widget.target));
+                print("[*] detail 화면으로 보내지는 data : ${temp}");
+                Get.to(() => DetailContentView(
+                      data: temp,
+                      isFromHome: true,
+                    ));
+              } else {
+                Get.to(() => const App());
+              }
+            },
+            child: const Text("자세히 보기"))
+      ],
     );
   }
 }

--- a/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux
@@ -1,1 +1,1 @@
-/Users/kwontaehyun/flutter/.pub-cache/hosted/pub.dartlang.org/flutter_secure_storage_linux-1.1.1/
+/Users/chaeeunseo/.pub-cache/hosted/pub.dartlang.org/flutter_secure_storage_linux-1.1.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
@@ -1,1 +1,1 @@
-/Users/kwontaehyun/flutter/.pub-cache/hosted/pub.dartlang.org/path_provider_linux-2.1.7/
+/Users/chaeeunseo/.pub-cache/hosted/pub.dartlang.org/path_provider_linux-2.1.7/

--- a/linux/flutter/ephemeral/.plugin_symlinks/share_plus_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/share_plus_linux
@@ -1,1 +1,1 @@
-/Users/kwontaehyun/flutter/.pub-cache/hosted/pub.dartlang.org/share_plus_linux-3.0.0/
+/Users/chaeeunseo/.pub-cache/hosted/pub.dartlang.org/share_plus_linux-3.0.0/

--- a/linux/flutter/ephemeral/.plugin_symlinks/shared_preferences_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/shared_preferences_linux
@@ -1,1 +1,1 @@
-/Users/kwontaehyun/flutter/.pub-cache/hosted/pub.dartlang.org/shared_preferences_linux-2.1.1/
+/Users/chaeeunseo/.pub-cache/hosted/pub.dartlang.org/shared_preferences_linux-2.1.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
@@ -1,1 +1,1 @@
-/Users/kwontaehyun/flutter/.pub-cache/hosted/pub.dartlang.org/url_launcher_linux-3.0.1/
+/Users/chaeeunseo/.pub-cache/hosted/pub.dartlang.org/url_launcher_linux-3.0.1/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -608,21 +608,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
@@ -685,7 +685,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   path_drawing:
     dependency: transitive
     description:
@@ -970,7 +970,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -991,21 +991,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## [CB-335]

bug/eventPopUpToBasic_CB-335 브랜치를 develop 브랜치에 병합

- custom 이벤트 팝업이 에뮬레이터나 폰에서는 정상 작동하나, 앱스토어에 업로드된 버전을 다운로드하면 버튼이 길어지거나 글씨가 안 보이는 문제가 발생함
- 이러한 이슈는 업데이트 후 다운로드 받아봐야 알 수 있기 때문에 디버깅이 힘듦
- 하지만, 이벤트 팝업을 활용해야 하지 못해 불편을 겪고 있어서 디자인을 뺀 기본 버전으로 되돌리기로 결정
- 기본 alert dialog 를 활용하여 이벤트 팝업으로 되돌림

[CB-335]: https://chocobread.atlassian.net/browse/CB-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ