### PR TITLE
[CB-339] 상세페이지 링크 외부 브라우저 열기로 처리

### DIFF
--- a/lib/page/detail.dart
+++ b/lib/page/detail.dart
@@ -1109,7 +1109,7 @@ class _DetailContentViewState extends State<DetailContentView> {
           final Uri url = Uri.parse(widget.data["link"]);
           if (await canLaunchUrl(url)) {
             // can launch function checks whether the device can launch url before invoking the launch function
-            await launchUrl(url);
+            await launchUrl(url, mode: LaunchMode.externalApplication);
           } else {
             // throw "could not launch $url";
             // url을 열 수 없는 경우, url을 눌러도 반응하지 않는다.

--- a/lib/page/detail.dart
+++ b/lib/page/detail.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:chocobread/constants/sizes_helper.dart';
@@ -1109,7 +1110,11 @@ class _DetailContentViewState extends State<DetailContentView> {
           final Uri url = Uri.parse(widget.data["link"]);
           if (await canLaunchUrl(url)) {
             // can launch function checks whether the device can launch url before invoking the launch function
-            await launchUrl(url, mode: LaunchMode.externalApplication);
+            if (Platform.isIOS) {
+              await launchUrl(url);
+            } else {
+              await launchUrl(url, mode: LaunchMode.externalApplication);
+            }
           } else {
             // throw "could not launch $url";
             // url을 열 수 없는 경우, url을 눌러도 반응하지 않는다.


### PR DESCRIPTION
## [CB-339] 상세페이지 링크 외부 브라우저 열기로 처리

bug/detailLinkExternalBrowser_CB-339 브랜치를 develop 브랜치에 병합

- 덕관이네 귤 농장 콜라보 상세 페이지 내 판매 링크(구글 폼즈)가 인 앱 웹뷰에서 열리지 않는 문제 발생
- 해결 위해 인 앱 웹뷰로 열리지 않는 경우, 외부 브라우저에서 열리는 것으로 처리

[CB-339]: https://chocobread.atlassian.net/browse/CB-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ